### PR TITLE
Fix activity and achievements metrics generation

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Classic
-        uses: lowlighter/metrics@latest
+        uses: lowlighter/metrics@v3.34
         with:
           user: hoangsvit
           filename: img/classic.svg
@@ -26,7 +26,7 @@ jobs:
           plugin_lines: yes
 
       - name: Achievements Compact display
-        uses: lowlighter/metrics@latest
+        uses: lowlighter/metrics@v3.34
         with:
           user: hoangsvit
           filename: img/achievements.compact.svg
@@ -36,13 +36,14 @@ jobs:
           base: ""
           plugin_achievements: yes
           plugin_achievements_only: >-
-            polyglot, stargazer, sponsor, deployer, member, maintainer, developer, scripter, packager, explorer, infographile, manager
+            polyglot, stargazer, deployer, member, maintainer, developer, scripter, packager, explorer, infographile, manager
           plugin_achievements_display: compact
-          plugin_achievements_threshold: X
+          plugin_achievements_threshold: C
 
       - name: Recent activity
-        uses: lowlighter/metrics@latest
+        uses: lowlighter/metrics@v3.34
         with:
+          user: hoangsvit
           filename: img/activity.svg
           optimize: svg
           experimental_features: --optimize-svg
@@ -55,7 +56,7 @@ jobs:
           config_timezone: Asia/Saigon
 
       - name: Followers
-        uses: lowlighter/metrics@latest
+        uses: lowlighter/metrics@v3.34
         with:
           user: hoangsvit
           filename: img/people.followers.svg
@@ -67,7 +68,7 @@ jobs:
           plugin_people_types: followers
 
       - name: Languages most used
-        uses: lowlighter/metrics@latest
+        uses: lowlighter/metrics@v3.34
         with:
           filename: img/languages.svg
           optimize: svg
@@ -77,7 +78,7 @@ jobs:
           plugin_languages: yes
 
       - name: WakaTime
-        uses: lowlighter/metrics@latest
+        uses: lowlighter/metrics@v3.34
         with:
           filename: img/wakatime.svg
           optimize: svg
@@ -90,7 +91,7 @@ jobs:
           plugin_wakatime_token: ${{ secrets.WAKATIME_TOKEN }}
 
       - name: LeetCode
-        uses: lowlighter/metrics@latest
+        uses: lowlighter/metrics@v3.34
         with:
           filename: img/leetcode.svg
           optimize: svg
@@ -102,7 +103,7 @@ jobs:
           plugin_leetcode_sections: solved, skills, recent
 
       - name: PageSpeed to eplus.dev
-        uses: lowlighter/metrics@latest
+        uses: lowlighter/metrics@v3.34
         with:
           filename: img/pagespeed-eplus.dev.svg
           optimize: svg


### PR DESCRIPTION
### Motivation
- Badge generation for `activity.svg` and `achievements.compact.svg` was failing due to upstream changes and configuration values. 
- Using `lowlighter/metrics@latest` can introduce unexpected breaking changes when the action is updated. 
- The recent-activity job lacked an explicit `user` which can cause the activity badge to point to the wrong account.

### Description
- Pin `uses: lowlighter/metrics` from `@latest` to `@v3.34` across all jobs in `.github/workflows/metrics.yml` to stabilize badge generation. 
- Add `user: hoangsvit` to the `Recent activity` job so activity data resolves to the intended account. 
- Remove `sponsor` from `plugin_achievements_only` and change `plugin_achievements_threshold` from `X` to `C` to avoid failures when rendering compact achievements. 
- Updated and committed `.github/workflows/metrics.yml` with these changes.

### Testing
- Verified YAML changes with `git diff -- .github/workflows/metrics.yml` which showed the intended modifications and succeeded. 
- Inspected the updated workflow file with `nl -ba .github/workflows/metrics.yml` to confirm the `uses`, `user`, and achievements config values were applied. 
- Committed the change with `git commit -m "Fix metrics workflow for activity and achievements badges"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddfcfdd4a48328b6b8b5a3a80c02d1)