### PR TITLE
Update metrics workflow: run every 6 hours and tweak activity plugin options

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,6 +1,6 @@
 name: Get Metrics
 on:
-  schedule: [{ cron: "*/5 * * * *" }]
+  schedule: [{ cron: "0 */6 * * *" }]
   workflow_dispatch:
   push: { branches: ["master", "main"] }
 jobs:
@@ -50,8 +50,11 @@ jobs:
           token: ${{ secrets.METRICS_TOKEN }}
           base: ""
           plugin_activity: yes
-          # plugin_activity_limit: 5
-          # plugin_activity_days: 0
+          plugin_activity_limit: 5
+          plugin_activity_load: 300
+          plugin_activity_days: 0
+          plugin_activity_visibility: all
+          plugin_activity_timestamps: no
           plugin_activity_filter: issue, pr, release, fork, review, ref/create
           config_timezone: Asia/Saigon
 


### PR DESCRIPTION
### Motivation
- Reduce the frequency of the metrics workflow from every 5 minutes to every 6 hours to lower API usage and processing overhead.
- Improve the activity widget output by enabling and tuning activity plugin options for clearer, broader results.

### Description
- Changed the scheduled cron from `"*/5 * * * *"` to `"0 */6 * * *"` in `.github/workflows/metrics.yml` to run the job every 6 hours.
- Enabled `plugin_activity_limit` and set it to `5` for the Recent activity step.
- Added `plugin_activity_load: 300`, `plugin_activity_visibility: all`, and `plugin_activity_timestamps: no` to expand load, show all activity visibility, and disable timestamps for the activity plugin.

### Testing
- No automated tests were run as part of this change; the update is limited to the GitHub Actions workflow configuration file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddffe535b88328929a21343a1971f5)